### PR TITLE
Fix concurrency issue when retrieving rates

### DIFF
--- a/forex-mtl/.scalafmt.conf
+++ b/forex-mtl/.scalafmt.conf
@@ -1,9 +1,9 @@
 align.openParenCallSite                      = false
-align.tokens                                 = ["%", "%%", {code = "=>", owner = "Case"}, {code = "=", owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type))"}, ]
+align.tokens                                 = ["%", "%%", {code = "=>", owner = "Case"}, {code = "<-", owner = "Enumerator.Generator"}, {code = "=", owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type))"}, ]
 align.arrowEnumeratorGenerator               = true
 binPack.parentConstructors                   = false
 danglingParentheses                          = true
-maxColumn                                    = 120
+maxColumn                                    = 130
 newlines.afterImplicitKWInVerticalMultiline  = true
 newlines.beforeImplicitKWInVerticalMultiline = true
 project.excludeFilters                       = [ .scalafmt.conf ]

--- a/forex-mtl/README.md
+++ b/forex-mtl/README.md
@@ -38,7 +38,8 @@ The main assumptions taken while developing this application are as follow:
   requesting fresh rates from OneForge Api. This call does NOT increase the quota count towards the limit.
 - There are only 9 currencies supported in this application - it is just a matter of adding/removing them to/from the codebase to have them supported.
   The OneForge `/quotes` Api, returns all the currencies if the `pairs` query parameter gets removed. However, the domain Currency class must be updated
-  to support all of them.
+  to support all of them. **Note:** considering the limitation of a GET request (8KB), there are 701 possible combinations of unique pairs supported by OneForge,
+  this is well below the mentioned limit but it must be noted.
 - From the given requirements, it is clear that availability of the service is the main key point so I decided to make one call and return all of the supported currencies at once.
   (`The application should at least support 10.000 requests per day`)
   

--- a/forex-mtl/src/main/scala/forex/Main.scala
+++ b/forex-mtl/src/main/scala/forex/Main.scala
@@ -34,7 +34,7 @@ class Application[F[_]: ConcurrentEffect: Timer] {
                      .stream
 
       logger        <- Stream.eval(Slf4jLogger.create[F])
-      caffeineCache <- Stream.eval(Sync[F].delay(CaffeineCache[Map[Any, Json]]))
+      caffeineCache <- Stream.eval(Sync[F].delay(CaffeineCache[Map[Json, Json]]))
 
       module = Module[F](config, httpClient, caffeineCache, logger)
 

--- a/forex-mtl/src/main/scala/forex/Main.scala
+++ b/forex-mtl/src/main/scala/forex/Main.scala
@@ -26,17 +26,15 @@ class Application[F[_]: ConcurrentEffect: Timer] {
   def stream: Stream[F, Unit] =
     for {
       config <- Config.stream("app")
-
       httpClient <- BlazeClientBuilder[F](fromExecutor(newFixedThreadPool(config.http.client.maxConnections)))
-        .withMaxTotalConnections(config.http.client.maxConnections)
-        .withMaxConnectionsPerRequestKey(_ => config.http.client.maxConnections)
-        .withMaxWaitQueueLimit(-1)
-        .withRequestTimeout(config.http.client.timeout)
-        .stream
+                     .withMaxTotalConnections(config.http.client.maxConnections)
+                     .withMaxConnectionsPerRequestKey(_ => config.http.client.maxConnections)
+                     .withMaxWaitQueueLimit(-1)
+                     .withRequestTimeout(config.http.client.timeout)
+                     .stream
 
-      logger <- Stream.eval(Slf4jLogger.create[F])
-
-      caffeineCache <- Stream.eval(Sync[F].delay(CaffeineCache[Map[String, Json]]))
+      logger        <- Stream.eval(Slf4jLogger.create[F])
+      caffeineCache <- Stream.eval(Sync[F].delay(CaffeineCache[Map[Any, Json]]))
 
       module = Module[F](config, httpClient, caffeineCache, logger)
 
@@ -45,5 +43,4 @@ class Application[F[_]: ConcurrentEffect: Timer] {
             .withHttpApp(module.httpApp)
             .serve
     } yield ()
-
 }

--- a/forex-mtl/src/main/scala/forex/Module.scala
+++ b/forex-mtl/src/main/scala/forex/Module.scala
@@ -1,9 +1,9 @@
 package forex
 
-import cats.effect.{ Concurrent, Timer }
+import cats.effect.{Concurrent, Timer}
 import forex.config.ApplicationConfig
 import forex.http.rates.RatesHttpRoutes
-import forex.infrastructure.{ CacheClient, HttpClient }
+import forex.infrastructure.{CacheClient, HttpClient}
 import forex.programs._
 import forex.services._
 import io.chrisdavenport.log4cats.Logger
@@ -11,7 +11,7 @@ import io.circe.Json
 import org.http4s._
 import org.http4s.client.Client
 import org.http4s.implicits._
-import org.http4s.server.middleware.{ AutoSlash, Timeout }
+import org.http4s.server.middleware.{AutoSlash, Timeout}
 import scalacache.Cache
 
 class Module[F[_]: Concurrent: Timer: Logger] private (
@@ -58,7 +58,7 @@ object Module {
   def apply[F[_]: Concurrent: Timer](
       config: ApplicationConfig,
       httpBlazeClient: Client[F],
-      scalaCache: Cache[Map[String, Json]],
+      scalaCache: Cache[Map[Any, Json]],
       log4cats: Logger[F]
   ): Module[F] = {
     implicit val logger: Logger[F] = log4cats

--- a/forex-mtl/src/main/scala/forex/Module.scala
+++ b/forex-mtl/src/main/scala/forex/Module.scala
@@ -58,7 +58,7 @@ object Module {
   def apply[F[_]: Concurrent: Timer](
       config: ApplicationConfig,
       httpBlazeClient: Client[F],
-      scalaCache: Cache[Map[Any, Json]],
+      scalaCache: Cache[Map[Json, Json]],
       log4cats: Logger[F]
   ): Module[F] = {
     implicit val logger: Logger[F] = log4cats

--- a/forex-mtl/src/main/scala/forex/domain/Currency.scala
+++ b/forex-mtl/src/main/scala/forex/domain/Currency.scala
@@ -23,7 +23,7 @@ object Currency extends Enum[Currency] {
 
   val values: immutable.IndexedSeq[Currency] = findValues
 
-  val fromToPairs: Seq[Rate.Pair] = for {
+  val uniqueProductPairs: Seq[Rate.Pair] = for {
     from <- values
     to <- values if from != to
   } yield Rate.Pair(from, to)

--- a/forex-mtl/src/main/scala/forex/domain/Price.scala
+++ b/forex-mtl/src/main/scala/forex/domain/Price.scala
@@ -3,7 +3,7 @@ package forex.domain
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.semiauto.{deriveUnwrappedDecoder, deriveUnwrappedEncoder}
 
-case class Price(value: BigDecimal) extends AnyVal
+final case class Price(value: BigDecimal) extends AnyVal
 
 object Price {
   def apply(value: Int): Price =

--- a/forex-mtl/src/main/scala/forex/domain/Rate.scala
+++ b/forex-mtl/src/main/scala/forex/domain/Rate.scala
@@ -3,7 +3,7 @@ package forex.domain
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import io.circe.{ Decoder, Encoder }
 
-case class Rate(
+final case class Rate(
     pair: Rate.Pair,
     price: Price,
     timestamp: Timestamp

--- a/forex-mtl/src/main/scala/forex/domain/Rate.scala
+++ b/forex-mtl/src/main/scala/forex/domain/Rate.scala
@@ -1,7 +1,8 @@
 package forex.domain
 
-import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
-import io.circe.{ Decoder, Encoder }
+import cats.syntax.show._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 
 final case class Rate(
     pair: Rate.Pair,
@@ -14,7 +15,7 @@ object Rate {
       from: Currency,
       to: Currency
   ) {
-    val asString: String = s"$from$to"
+    lazy val asString: String = show"$from$to"
   }
 
   implicit val rateEncoder: Encoder[Rate] =

--- a/forex-mtl/src/main/scala/forex/domain/Timestamp.scala
+++ b/forex-mtl/src/main/scala/forex/domain/Timestamp.scala
@@ -2,24 +2,30 @@ package forex.domain
 
 import java.time.Instant.ofEpochSecond
 import java.time.OffsetDateTime.ofInstant
-import java.time.temporal.ChronoUnit
 import java.time.{OffsetDateTime, ZoneOffset}
+import java.util.concurrent.TimeUnit
 
+import cats.Functor
+import cats.effect.Clock
+import cats.syntax.functor._
 import io.circe.generic.extras.semiauto.{deriveUnwrappedDecoder, deriveUnwrappedEncoder}
 import io.circe.{Decoder, Encoder}
 
 final case class Timestamp(value: OffsetDateTime) extends AnyVal
 
 object Timestamp {
-  def now: Timestamp =
-    Timestamp(OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS))
+  def now[F[_]: Clock: Functor]: F[Timestamp] =
+    Clock[F].realTime(TimeUnit.SECONDS).map(toTimestamp)
 
   implicit val timestampEncoder: Encoder[Timestamp] =
     deriveUnwrappedEncoder
 
   implicit val timestampDecoder: Decoder[Timestamp] =
     List[Decoder[Timestamp]](
-      Decoder.decodeLong.map(epochSecond => Timestamp(ofInstant(ofEpochSecond(epochSecond), ZoneOffset.UTC))),
+      Decoder.decodeLong.map(toTimestamp),
       deriveUnwrappedDecoder
     ).reduceLeft(_ or _)
+
+  private def toTimestamp(epochSecond: Long): Timestamp =
+    Timestamp(ofInstant(ofEpochSecond(epochSecond), ZoneOffset.UTC))
 }

--- a/forex-mtl/src/main/scala/forex/domain/Timestamp.scala
+++ b/forex-mtl/src/main/scala/forex/domain/Timestamp.scala
@@ -8,7 +8,7 @@ import java.time.{OffsetDateTime, ZoneOffset}
 import io.circe.generic.extras.semiauto.{deriveUnwrappedDecoder, deriveUnwrappedEncoder}
 import io.circe.{Decoder, Encoder}
 
-case class Timestamp(value: OffsetDateTime) extends AnyVal
+final case class Timestamp(value: OffsetDateTime) extends AnyVal
 
 object Timestamp {
   def now: Timestamp =

--- a/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
@@ -29,8 +29,8 @@ class RatesHttpRoutes[F[_]: Logger](
   private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
     case GET -> Root :? FromQueryParam(fromOrError) +& ToQueryParam(toOrError) => {
       val rateOrError = for {
-        from <- F.fromEither(fromOrError)
-        to <- F.fromEither(toOrError)
+        from        <- F.fromEither(fromOrError)
+        to          <- F.fromEither(toOrError)
         rateOrError <- handleGetRate(RatesProgramProtocol.GetRatesRequest(from, to)).flatMap(F.fromEither)
       } yield rateOrError
 
@@ -49,7 +49,7 @@ class RatesHttpRoutes[F[_]: Logger](
 
   private def logAndReturnInternalError(uncaughtError: Throwable): F[Response[F]] =
     for {
-      _ <- Logger[F].error(uncaughtError)("Something went wrong. Please try again or check the logs.")
+      _                   <- Logger[F].error(uncaughtError)("Something went wrong. Please try again or check the logs.")
       internalServerError <- InternalServerError(ApiErrorResponse(uncaughtError.getMessage))
     } yield internalServerError
 

--- a/forex-mtl/src/main/scala/forex/infrastructure/CacheClient.scala
+++ b/forex-mtl/src/main/scala/forex/infrastructure/CacheClient.scala
@@ -3,35 +3,35 @@ package forex.infrastructure
 import cats.effect.Async
 import cats.implicits._
 import io.circe.syntax.EncoderOps
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{Decoder, Encoder, Json}
 import scalacache._
 
 import scala.concurrent.duration.Duration
 
-class CacheClient[F[_]](implicit cache: Cache[Map[Any, Json]], M: Mode[F], F: Async[F]) {
+class CacheClient[F[_]](implicit cache: Cache[Map[Json, Json]], M: Mode[F], F: Async[F]) {
 
-  def getEntryValue[K, V: Decoder](cacheKeyName: String)(entryKey: K): F[Option[V]] =
+  def getEntryValue[K: Encoder, V: Decoder](cacheKeyName: String)(entryKey: K): F[Option[V]] =
     for {
-      maybeValue   <- F.map(get(cacheKeyName))(_.flatMap(_.get(entryKey)))
+      maybeValue   <- F.map(get[F, Map[Json, Json]](cacheKeyName))(_.flatMap(_.get(entryKey.asJson)))
       decodedValue <- F.fromEither(maybeValue.traverse(_.as[V]))
     } yield decodedValue
 
-  def putEntries[K, V: Encoder](cacheKeyName: String, timeout: Option[Duration])(
+  def putEntries[K: Encoder, V: Encoder](cacheKeyName: String, timeout: Option[Duration])(
       entries: Map[K, V]
   ): F[Done] =
     if (entries.isEmpty) F.pure(Done)
     else
       F.as(
-        put[F, Map[Any, Json]](cacheKeyName)(entries.map { case (key, value) => (key.asInstanceOf[Any], value.asJson) }, timeout),
+        put[F, Map[Json, Json]](cacheKeyName)(entries.map { case (key, value) => (key.asJson, value.asJson) }, timeout),
         Done
       )
 }
 
 object CacheClient {
 
-  def apply[F[_]: Async](underlyingCache: Cache[Map[Any, Json]]): CacheClient[F] = {
-    implicit val mode: Mode[F]                = scalacache.CatsEffect.modes.async[F]
-    implicit val cache: Cache[Map[Any, Json]] = underlyingCache
+  def apply[F[_]: Async](underlyingCache: Cache[Map[Json, Json]]): CacheClient[F] = {
+    implicit val mode: Mode[F]                 = scalacache.CatsEffect.modes.async[F]
+    implicit val cache: Cache[Map[Json, Json]] = underlyingCache
     new CacheClient[F]
   }
 }

--- a/forex-mtl/src/main/scala/forex/infrastructure/CacheClient.scala
+++ b/forex-mtl/src/main/scala/forex/infrastructure/CacheClient.scala
@@ -8,27 +8,30 @@ import scalacache._
 
 import scala.concurrent.duration.Duration
 
-class CacheClient[F[_]](implicit cache: Cache[Map[String, Json]], M: Mode[F], F: Async[F]) {
+class CacheClient[F[_]](implicit cache: Cache[Map[Any, Json]], M: Mode[F], F: Async[F]) {
 
-  def getEntryValue[A: Decoder](cacheKeyName: String)(entryKey: String): F[Option[A]] =
+  def getEntryValue[K, V: Decoder](cacheKeyName: String)(entryKey: K): F[Option[V]] =
     for {
-      maybeValue <- F.map(get[F, Map[String, Json]](cacheKeyName))(_.flatMap(_.get(entryKey)))
-      decodedValueOrError = maybeValue.traverse(_.as[A])
-      decodedValue <- F.fromEither(decodedValueOrError)
+      maybeValue   <- F.map(get(cacheKeyName))(_.flatMap(_.get(entryKey)))
+      decodedValue <- F.fromEither(maybeValue.traverse(_.as[V]))
     } yield decodedValue
 
-  def putEntries[A: Encoder](cacheKeyName: String, timeout: Option[Duration])(
-    entries: Map[String, A]
+  def putEntries[K, V: Encoder](cacheKeyName: String, timeout: Option[Duration])(
+      entries: Map[K, V]
   ): F[Done] =
     if (entries.isEmpty) F.pure(Done)
-    else F.as(put[F, Map[String, Json]](cacheKeyName)(entries.mapValues(_.asJson), timeout), Done)
+    else
+      F.as(
+        put[F, Map[Any, Json]](cacheKeyName)(entries.map { case (key, value) => (key.asInstanceOf[Any], value.asJson) }, timeout),
+        Done
+      )
 }
 
 object CacheClient {
 
-  def apply[F[_]: Async](underlyingCache: Cache[Map[String, Json]]): CacheClient[F] = {
-    implicit val mode: Mode[F]                   = scalacache.CatsEffect.modes.async[F]
-    implicit val cache: Cache[Map[String, Json]] = underlyingCache
+  def apply[F[_]: Async](underlyingCache: Cache[Map[Any, Json]]): CacheClient[F] = {
+    implicit val mode: Mode[F]                = scalacache.CatsEffect.modes.async[F]
+    implicit val cache: Cache[Map[Any, Json]] = underlyingCache
     new CacheClient[F]
   }
 }

--- a/forex-mtl/src/main/scala/forex/infrastructure/HttpClient.scala
+++ b/forex-mtl/src/main/scala/forex/infrastructure/HttpClient.scala
@@ -24,7 +24,7 @@ object HttpClient {
 
   def createGetRequest[F[_]](
       uri: Uri,
-      headers: Seq[Header] = List(JsonContentTypeHeader)
+      headers: List[Header] = List(JsonContentTypeHeader)
   ): Request[F] =
     Request[F](method = Method.GET, uri = uri)
       .withHeaders(Headers.of(headers: _*))

--- a/forex-mtl/src/main/scala/forex/programs/rates/Converters.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Converters.scala
@@ -15,9 +15,9 @@ object Converters {
   }
 
   private[rates] implicit class RateResponseOps(val rates: Seq[Rate]) {
-    def toRatesMap: Map[String, Rate] =
+    def asRatesMap: Map[Rate.Pair, Rate] =
       rates.map { rate =>
-        (rate.pair.asString, Rate(rate.pair, rate.price, rate.timestamp))
+        (rate.pair, Rate(rate.pair, rate.price, rate.timestamp))
       }.toMap
   }
 }

--- a/forex-mtl/src/main/scala/forex/programs/rates/Converters.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Converters.scala
@@ -14,7 +14,7 @@ object Converters {
       )
   }
 
-  private[rates] implicit class RateResponseOps(val rates: Seq[Rate]) {
+  private[rates] implicit class RateResponseOps(val rates: List[Rate]) {
     def asRatesMap: Map[Rate.Pair, Rate] =
       rates.map { rate =>
         (rate.pair, Rate(rate.pair, rate.price, rate.timestamp))

--- a/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
@@ -18,7 +18,7 @@ import forex.services.{RatesService, ServiceErrorOr}
 import io.chrisdavenport.log4cats.Logger
 
 class Program[F[_]: FlatMap: Logger: Clock] private[rates] (
-    getFreshRates: => F[ServiceErrorOr[Seq[Rate]]],
+    getFreshRates: => F[ServiceErrorOr[List[Rate]]],
     getCachedRate: Rate.Pair => F[Option[Rate]],
     setCachedRates: Map[Rate.Pair, Rate] => F[Done]
 )(implicit F: MonadError[F, Throwable])

--- a/forex-mtl/src/main/scala/forex/programs/rates/errors.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/errors.scala
@@ -1,6 +1,6 @@
 package forex.programs.rates
 
-import forex.services.rates.errors.{ Error => RatesServiceError }
+import forex.services.rates.errors.{Error => RatesServiceError}
 
 object errors {
 

--- a/forex-mtl/src/main/scala/forex/services/rates/Algebra.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Algebra.scala
@@ -4,5 +4,5 @@ import forex.domain.Rate
 import forex.services.ServiceErrorOr
 
 trait Algebra[F[_]] {
-  def getRates: F[ServiceErrorOr[Seq[Rate]]]
+  def getRates: F[ServiceErrorOr[List[Rate]]]
 }

--- a/forex-mtl/src/main/scala/forex/services/rates/Converters.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Converters.scala
@@ -7,7 +7,7 @@ object Converters {
   import Protocol._
 
   private[rates] implicit class GetRatesResponseOps(val rateResponse: GetRatesResponse) {
-    def toRates: Seq[Rate] =
+    def toRates: List[Rate] =
       rateResponse.rates.map(
         rateResponse =>
           Rate(

--- a/forex-mtl/src/main/scala/forex/services/rates/OneForgeApi.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/OneForgeApi.scala
@@ -8,7 +8,7 @@ import org.http4s.Request
 object OneForgeApi {
 
   def buildOneForgeRequestQuotes[F[_]](oneForgeConfig: OneForgeConfig): Request[F] = {
-    val pairs = Currency.fromToPairs.map(_.asString).mkString(",")
+    val pairs = Currency.uniqueProductPairs.map(_.asString).mkString(",")
     createGetRequest[F](
       uri = (oneForgeConfig.uri / "quotes")
         .withQueryParam("pairs", pairs)

--- a/forex-mtl/src/main/scala/forex/services/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Protocol.scala
@@ -29,9 +29,9 @@ object Protocol {
     private[rates] val oneForgeRateResponseDecoder: Decoder[RateResponse] = (cursor: HCursor) =>
       for {
         rawSymbol <- cursor.downField("symbol").as[String]
-        from <- fromString(rawSymbol.take(3)).as[Currency]
-        to <- fromString(rawSymbol.drop(3)).as[Currency]
-        price <- cursor.downField("price").as[Price]
+        from      <- fromString(rawSymbol.take(3)).as[Currency]
+        to        <- fromString(rawSymbol.drop(3)).as[Currency]
+        price     <- cursor.downField("price").as[Price]
         timestamp <- cursor.downField("timestamp").as[Timestamp]
       } yield OneForgeRateResponse(Rate.Pair(from, to), price, timestamp)
   }
@@ -40,12 +40,11 @@ object Protocol {
 
     final case class OneForgeQuotaResponse(remaining: Int, hoursUntilReset: Int) extends QuotaResponse
 
-    private[rates] val oneForgeQuotaResponseDecoder: Decoder[OneForgeQuotaResponse] =
-      (cursor: HCursor) =>
-        for {
-          quotaRemaining <- cursor.downField("quota_remaining").as[Int]
-          hoursUntilReset <- cursor.downField("hours_until_reset").as[Int]
-        } yield OneForgeQuotaResponse(quotaRemaining, hoursUntilReset)
+    private[rates] val oneForgeQuotaResponseDecoder: Decoder[OneForgeQuotaResponse] = (cursor: HCursor) =>
+      for {
+        quotaRemaining  <- cursor.downField("quota_remaining").as[Int]
+        hoursUntilReset <- cursor.downField("hours_until_reset").as[Int]
+      } yield OneForgeQuotaResponse(quotaRemaining, hoursUntilReset)
   }
 
   lazy implicit val rateResponseDecoder: Decoder[RateResponse] = {

--- a/forex-mtl/src/main/scala/forex/services/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Protocol.scala
@@ -8,7 +8,7 @@ import io.circe.{Decoder, HCursor}
 
 object Protocol {
 
-  case class GetRatesResponse(rates: Seq[RateResponse])
+  case class GetRatesResponse(rates: List[RateResponse])
   case class GetQuotaResponse(quota: QuotaResponse)
 
   sealed trait RateResponse {

--- a/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneForgeInterpreter.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneForgeInterpreter.scala
@@ -1,7 +1,7 @@
 package forex.services.rates.interpreters
 
+import cats.MonadError
 import cats.data.EitherT
-import cats.effect.Sync
 import cats.implicits._
 import forex.config.OneForgeConfig
 import forex.domain.Rate
@@ -18,7 +18,7 @@ class OneForgeInterpreter[F[_]: Logger](
     oneForgeConfig: OneForgeConfig,
     fetchRates: Request[F] => F[ErrorOr[GetRatesResponse]],
     fetchQuota: Request[F] => F[ErrorOr[GetQuotaResponse]]
-)(implicit F: Sync[F])
+)(implicit F: MonadError[F, Throwable])
     extends Algebra[F] {
 
   override def getRates: F[ServiceErrorOr[Seq[Rate]]] =

--- a/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneForgeInterpreter.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneForgeInterpreter.scala
@@ -21,7 +21,7 @@ class OneForgeInterpreter[F[_]: Logger](
 )(implicit F: MonadError[F, Throwable])
     extends Algebra[F] {
 
-  override def getRates: F[ServiceErrorOr[Seq[Rate]]] =
+  override def getRates: F[ServiceErrorOr[List[Rate]]] =
     (for {
       _                  <- EitherT(ensureAvailableQuotaOrError)
       freshRatesResponse <- EitherT(executeFetchRates)

--- a/forex-mtl/src/test/scala/forex/TestInstances.scala
+++ b/forex-mtl/src/test/scala/forex/TestInstances.scala
@@ -1,13 +1,15 @@
 package forex
 
-import java.time.{ LocalDateTime, OffsetDateTime, ZoneOffset }
+import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
 
-import cats.effect.IO
+import cats.effect.{Clock, IO}
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.noop.NoOpLogger
 import io.circe.Json
 import scalacache.Cache
 import scalacache.caffeine.CaffeineCache
+
+import scala.concurrent.duration.{MILLISECONDS, NANOSECONDS, TimeUnit}
 
 object TestInstances {
 
@@ -19,4 +21,11 @@ object TestInstances {
     LocalDateTime.of(2019, 8, 3, 0, 0, 0, 0),
     ZoneOffset.UTC
   )
+
+  class IOClock extends Clock[IO] {
+    final def realTime(unit: TimeUnit): IO[Long] =
+      IO(unit.convert(System.currentTimeMillis(), MILLISECONDS))
+    final def monotonic(unit: TimeUnit): IO[Long] =
+      IO(unit.convert(System.nanoTime(), NANOSECONDS))
+  }
 }

--- a/forex-mtl/src/test/scala/forex/TestInstances.scala
+++ b/forex-mtl/src/test/scala/forex/TestInstances.scala
@@ -13,7 +13,7 @@ object TestInstances {
 
   implicit val noopLogger: Logger[IO] = NoOpLogger.impl[IO]
 
-  val testCaffeineCache: Cache[Map[String, Json]] = CaffeineCache[Map[String, Json]]
+  val testCaffeineCache: Cache[Map[Any, Json]] = CaffeineCache[Map[Any, Json]]
 
   val testOffsetDateTime: OffsetDateTime = OffsetDateTime.of(
     LocalDateTime.of(2019, 8, 3, 0, 0, 0, 0),

--- a/forex-mtl/src/test/scala/forex/TestInstances.scala
+++ b/forex-mtl/src/test/scala/forex/TestInstances.scala
@@ -13,7 +13,7 @@ object TestInstances {
 
   implicit val noopLogger: Logger[IO] = NoOpLogger.impl[IO]
 
-  val testCaffeineCache: Cache[Map[Any, Json]] = CaffeineCache[Map[Any, Json]]
+  val testCaffeineCache: Cache[Map[Json, Json]] = CaffeineCache[Map[Json, Json]]
 
   val testOffsetDateTime: OffsetDateTime = OffsetDateTime.of(
     LocalDateTime.of(2019, 8, 3, 0, 0, 0, 0),

--- a/forex-mtl/src/test/scala/forex/domain/CurrencySpec.scala
+++ b/forex-mtl/src/test/scala/forex/domain/CurrencySpec.scala
@@ -17,7 +17,7 @@ class CurrencySpec extends FreeSpec with Matchers {
 
     "fromToPairs" - {
       "should construct the product of all unique currency pair" in {
-        fromToPairs.size shouldBe ((values.size * values.size) - values.size)
+        uniqueProductPairs.size shouldBe ((values.size * values.size) - values.size)
       }
     }
 

--- a/forex-mtl/src/test/scala/forex/infrastructure/CacheClientSpec.scala
+++ b/forex-mtl/src/test/scala/forex/infrastructure/CacheClientSpec.scala
@@ -19,17 +19,17 @@ class CacheClientSpec extends FreeSpec with Matchers with TestUtilsIO {
       runIO(cacheClient.putEntries(cacheKey, None)(Map("key1" -> "value1", "key2" -> "value2")))
 
       "should successfully retrieve entry value" in {
-        val expectedValue = cacheClient.getEntryValue[Json](cacheKey)("key2")
+        val expectedValue = cacheClient.getEntryValue[String, Json](cacheKey)("key2")
         runIO(expectedValue) shouldBe Some(Json.fromString("value2"))
       }
 
       "should return NONE when entry is not found" in {
-        val expectedValue = cacheClient.getEntryValue[Json](cacheKey)("MISSING-ENTRY-KEY")
+        val expectedValue = cacheClient.getEntryValue[String, Json](cacheKey)("MISSING-ENTRY-KEY")
         runIO(expectedValue) shouldBe None
       }
 
       "should return NONE when current cache is not found" in {
-        val expectedValue = cacheClient.getEntryValue[Json]("MISSING-CACHE-KEY")("key2")
+        val expectedValue = cacheClient.getEntryValue[String, Json]("MISSING-CACHE-KEY")("key2")
         runIO(expectedValue) shouldBe None
       }
     }
@@ -39,19 +39,19 @@ class CacheClientSpec extends FreeSpec with Matchers with TestUtilsIO {
       runIO(cacheClient.putEntries(cacheKey, Some(1.nano))(Map("key" -> "value")))
 
       "should return NONE when timeout is expired" in {
-        val expectedValue = cacheClient.getEntryValue[Json](cacheKey)("key")
+        val expectedValue = cacheClient.getEntryValue[String, Json](cacheKey)("key")
         runIO(expectedValue) shouldBe None
       }
     }
 
     "setEntries" - {
       "should successfully store entries" in {
-        val expectedResult = cacheClient.putEntries[String]("test-key", None)(Map("key1" -> "value1"))
+        val expectedResult = cacheClient.putEntries[String, Json]("test-key", None)(Map("key1" -> Json.fromString("value1")))
         runIO(expectedResult) shouldBe Done
       }
 
       "should short-circuit store operation when entries are empty" in {
-        val expectedResult = cacheClient.putEntries[String]("empty-map-key", None)(Map.empty)
+        val expectedResult = cacheClient.putEntries[String, Json]("empty-map-key", None)(Map.empty)
         runIO(expectedResult) shouldBe Done
       }
     }

--- a/forex-mtl/src/test/scala/forex/programs/rates/ConvertersSpec.scala
+++ b/forex-mtl/src/test/scala/forex/programs/rates/ConvertersSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class ConvertersSpec extends FlatSpec with Matchers {
 
   "asRatesMap" should "successfully convert rates into a map with the pair as key" in {
-    val rates        = Vector(RateFixtures.buildRate())
+    val rates        = List(RateFixtures.buildRate())
     val expectedRate = rates.head
     val expectedResult =
       Map(expectedRate.pair -> Rate(expectedRate.pair, expectedRate.price, expectedRate.timestamp))

--- a/forex-mtl/src/test/scala/forex/programs/rates/ConvertersSpec.scala
+++ b/forex-mtl/src/test/scala/forex/programs/rates/ConvertersSpec.scala
@@ -6,11 +6,11 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ConvertersSpec extends FlatSpec with Matchers {
 
-  "toRatesMap" should "successfully convert rates into a map with the pair as key" in {
-    val rates = Vector(RateFixtures.buildRate())
+  "asRatesMap" should "successfully convert rates into a map with the pair as key" in {
+    val rates        = Vector(RateFixtures.buildRate())
     val expectedRate = rates.head
     val expectedResult =
-      Map(s"${expectedRate.pair.asString}" -> Rate(expectedRate.pair, expectedRate.price, expectedRate.timestamp))
-    rates.toRatesMap shouldBe expectedResult
+      Map(expectedRate.pair -> Rate(expectedRate.pair, expectedRate.price, expectedRate.timestamp))
+    rates.asRatesMap shouldBe expectedResult
   }
 }

--- a/forex-mtl/src/test/scala/forex/programs/rates/ProgramSpec.scala
+++ b/forex-mtl/src/test/scala/forex/programs/rates/ProgramSpec.scala
@@ -1,16 +1,18 @@
 package forex.programs.rates
 
-import cats.effect.IO
+import cats.effect.{Clock, IO}
 import forex.TestInstances.{noopLogger, testOffsetDateTime}
-import forex.TestUtilsIO
 import forex.domain.Currency.{AUD, JPY}
 import forex.domain.{Price, Rate, RateFixtures, Timestamp}
 import forex.infrastructure.Done
 import forex.programs.rates.errors.Error.{CachedRateNotFound, RateLookupFailed, ServiceTemporaryUnavailable}
 import forex.services.rates.errors.Error.{OneForgeLookupFailed, OneForgeQuotaLimitExceeded}
+import forex.{TestInstances, TestUtilsIO}
 import org.scalatest.{FreeSpec, Matchers}
 
 class ProgramSpec extends FreeSpec with Matchers with TestUtilsIO {
+
+  implicit val clock: Clock[IO] = new TestInstances.IOClock
 
   "Program" - {
 
@@ -67,7 +69,7 @@ class ProgramSpec extends FreeSpec with Matchers with TestUtilsIO {
         )
 
         val expectedProgram = program.get(Protocol.GetRatesRequest(AUD, JPY))
-        an [RateLookupFailed] should be thrownBy runIO(expectedProgram)
+        an[RateLookupFailed] should be thrownBy runIO(expectedProgram)
       }
 
       "should return ServiceTemporaryUnavailable exception when it exceeds the daily quota to fetch fresh rates" in {

--- a/forex-mtl/src/test/scala/forex/programs/rates/ProgramSpec.scala
+++ b/forex-mtl/src/test/scala/forex/programs/rates/ProgramSpec.scala
@@ -22,7 +22,7 @@ class ProgramSpec extends FreeSpec with Matchers with TestUtilsIO {
 
       "should get cached rates when are found" in {
         val program: Program[IO] = new Program[IO](
-          IO.pure(Right(Vector(RateFixtures.buildRate()))),
+          IO.pure(Right(List(RateFixtures.buildRate()))),
           _ => IO.pure(Some(rate)),
           _ => IO.pure(Done)
         )
@@ -35,7 +35,7 @@ class ProgramSpec extends FreeSpec with Matchers with TestUtilsIO {
         val rate = Rate(Rate.Pair(from = AUD, to = JPY), Price(123.1234), Timestamp(testOffsetDateTime))
 
         val program: Program[IO] = new Program[IO](
-          IO.pure(Right(Vector(rate))),
+          IO.pure(Right(List(rate))),
           _ => IO.pure(None),
           _ => IO.pure(Done)
         )
@@ -46,7 +46,7 @@ class ProgramSpec extends FreeSpec with Matchers with TestUtilsIO {
 
       "should get a fixed rate when the currencies are the same" in {
         val program: Program[IO] = new Program[IO](
-          IO.pure(Right(Vector(rate))),
+          IO.pure(Right(List(rate))),
           _ => IO.pure(None),
           _ => IO.pure(Done)
         )
@@ -85,7 +85,7 @@ class ProgramSpec extends FreeSpec with Matchers with TestUtilsIO {
 
       "should return CachedRateNotFound exception when it fails to get fresh rates" in {
         val program: Program[IO] = new Program[IO](
-          IO.pure(Right(Vector.empty)),
+          IO.pure(Right(List.empty)),
           _ => IO.pure(None),
           _ => IO.pure(Done)
         )

--- a/forex-mtl/src/test/scala/forex/services/rates/ConvertersSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/ConvertersSpec.scala
@@ -9,7 +9,7 @@ class ConvertersSpec extends FlatSpec with Matchers {
   "toRates" should "successfully convert a GetRatesResponse into rates" in {
     val getRateResponse = ProtocolFixtures.buildGetRatesResponse()
     val expectedRate    = getRateResponse.rates.head
-    val expectedResult  = Seq(Rate(expectedRate.pair, expectedRate.price, expectedRate.timestamp))
+    val expectedResult  = List(Rate(expectedRate.pair, expectedRate.price, expectedRate.timestamp))
 
     getRateResponse.toRates shouldBe expectedResult
   }

--- a/forex-mtl/src/test/scala/forex/services/rates/OneForgeApiSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/OneForgeApiSpec.scala
@@ -1,7 +1,7 @@
 package forex.services.rates
 
 import forex.config.ConfigFixtures.testApplicationConfig
-import forex.domain.Currency.fromToPairs
+import forex.domain.Currency.uniqueProductPairs
 import org.http4s.Method
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -13,7 +13,7 @@ class OneForgeApiSpec extends FreeSpec with Matchers {
       val actualRequest  = OneForgeApi.buildOneForgeRequestQuotes(oneForgeConfig)
       actualRequest.uri.renderString should include("/quotes")
       actualRequest.method shouldBe Method.GET
-      actualRequest.params("pairs") shouldBe fromToPairs.map(_.asString).mkString(",")
+      actualRequest.params("pairs") shouldBe uniqueProductPairs.map(_.asString).mkString(",")
     }
   }
 

--- a/forex-mtl/src/test/scala/forex/services/rates/ProtocolFixtures.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/ProtocolFixtures.scala
@@ -12,7 +12,7 @@ import forex.services.rates.Protocol.{ GetQuotaResponse, GetRatesResponse }
 object ProtocolFixtures {
 
   def buildGetRatesResponse(
-      ratesResponse: Seq[Protocol.RateResponse] = Vector(buildOneForgeRateResponse())
+      ratesResponse: List[Protocol.RateResponse] = List(buildOneForgeRateResponse())
   ): GetRatesResponse = GetRatesResponse(ratesResponse)
 
   def buildOneForgeRateResponse(

--- a/forex-mtl/src/test/scala/forex/services/rates/ProtocolSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/ProtocolSpec.scala
@@ -34,7 +34,7 @@ class ProtocolSpec extends FreeSpec with Matchers {
 
     "should successfully decode GetRatesResponse containing OneForgeRatePair" in {
       val expectedResult = GetRatesResponse(
-        Vector(
+        List(
           buildOneForgeRateResponse(Rate.Pair(EUR, USD), Price(1.12134), testOffsetDateTime),
           buildOneForgeRateResponse(Rate.Pair(USD, JPY), Price(106.101), testOffsetDateTime)
         )

--- a/forex-mtl/src/test/scala/forex/services/rates/interpreters/OneForgeInterpreterSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/interpreters/OneForgeInterpreterSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.{FreeSpec, Matchers}
 class OneForgeInterpreterSpec extends FreeSpec with Matchers with TestUtilsIO {
 
   "OneForgeInterpreter" - {
-    val successfulGetRatesResponse = buildGetRatesResponse(Vector(buildOneForgeRateResponse()))
+    val successfulGetRatesResponse = buildGetRatesResponse(List(buildOneForgeRateResponse()))
 
     val interpreterSuccessful: Algebra[IO] = new OneForgeInterpreter[IO](
       oneForgeConfig = testApplicationConfig.http.oneForge,


### PR DESCRIPTION
# What
Fix a concurrency issue when multiple requests try to get a rate from the cache and otherwise refresh them by calling OneForge.

# Why
There must be a way to prevent multiple requests getting fresh rates from OneForge. As it stands, the application does not take into consideration the gap between reading/writing from/to the cache.
This gap can lead to concurrency issues and might impact the limited daily quota enforced by OneForge.

# How
- Add `synchronized` keyword to `getOrRefreshRates`
- Add additional `getCachedRate` call to enforce consistency between the first and the second time it gets called so it is safe to fetch fresh rates from OneForge. **Note:** the first time it gets called, there is no synchronization and therefore it is a non-blocking operation on successful (non-empty) result.
- Update `CacheClient` to accept any types as keys and not only `String`.
- Update `getCachedRate` and `setCachedRates` functions to take a `Rate.Pair` as key for the Map rather than a `String`
- Update `scalafmt` to better format the code and make it more readable
- Change typeclass `Sync`, when not required, in favour of `MonadError` to use the least powerful approach

<br/>

- [x] Refactor code
- [x] Update tests